### PR TITLE
Co\Redis Compatibility Mode  : Update 3.6.2 - Coroutine／Redis::setOptions.md  

### DIFF
--- a/doc/3.6.2 - Coroutine／Redis::setOptions.md
+++ b/doc/3.6.2 - Coroutine／Redis::setOptions.md
@@ -18,3 +18,5 @@ Coroutine\Redis::setOptions(array $options)
 `serialize`: 自动序列化, 默认关闭
 
 `reconnect`: 自动连接尝试次数, 如果连接由于超时等原因被close正常断开, 下一次发起请求时, 会自动尝试连接然后再发送请求, 默认为1次(true), 一旦失败指定次数后不会再继续尝试, 需手动重连. 该机制仅用于连接保活, 不会重发请求导致不幂等接口出错等问题
+
+`compatibility_mode`: hmGet/hGetAll/zRange/zRevRange/zRangeByScore/zRevRangeByScore 函数返回结果与php redis不一致的兼容解决方案，开启之后 Co\Redis 和 PHP Redis 返回结果一致，默认关闭


### PR DESCRIPTION
Co\Redis Compatibility Mode 
--------
Co\Redis 的函数 hmGet/hGetAll/zrange/zrevrange/zrangebyscore/zrevrangebyscore 返回结果与php redis不一致的问题，已经得到解决 [#2529](https://github.com/swoole/swoole-src/pull/2529)。为了兼容老版本，在加上 $redis->setOptions(['compatibility_mode' => true]); 配置后，即可保证 Co\Redis 和 PHP Redis 返回结果一致。

```php
go(function() {
	$redis = new Swoole\Coroutine\Redis();
	$redis->setOptions(['compatibility_mode' => true]);
	$redis->connect(REDIS_SERVER_HOST, REDIS_SERVER_PORT);

	$co_get_val = $redis->get('novalue');
	$co_zrank_val = $redis->zRank('novalue', 1);
	$co_hgetall_val = $redis->hGetAll('hkey');
	$co_hmget_val = $redis->hmGet('hkey', array(3, 5));
	$co_zrange_val = $redis->zRange('zkey', 0, 99, true);
	$co_zrevrange_val = $redis->zRevRange('zkey', 0, 99, true);
	$co_zrangebyscore_val = $redis->zRangeByScore('zkey', 0, 99, ['withscores' => true]);
	$co_zrevrangebyscore_val = $redis->zRevRangeByScore('zkey', 99, 0, ['withscores' => true]);
});
```